### PR TITLE
Add pusher-js 3.0.0

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -73,6 +73,7 @@ VERSIONS = %w{1.1 1.2 1.2.1 1.3 1.4 1.4.1 1.4.2 1.4.3 1.5.0 1.5.1
   2.0.0 2.0.1 2.0.2 2.0.3 2.0.4 2.0.5 2.0.6 2.0.7 2.0.8 2.0.9 2.0.10 2.0.11
   2.1.0 2.1.1 2.1.2 2.1.3 2.1.4 2.1.5 2.1.6
   2.2.0 2.2.1 2.2.2 2.2.3 2.2.4
+  3.0.0
 }
 
 get '/favicon.ico' do
@@ -100,9 +101,9 @@ get '/' do
   enabled_transports = if params[:transports].is_a?(Array)
     params[:transports]
   else
-    ["ws", "flash", "xhr_streaming", "xdr_streaming", "xhr_polling", "xdr_polling", "sockjs"]
+    supported_transports(@version)
   end
-  @transports = Hash[enabled_transports.map { |t| [t, true] }]
+  @selected_transports = Hash[enabled_transports.map { |t| [t, true] }]
 
   erb :public
 end
@@ -135,7 +136,9 @@ helpers do
   end
 
   def files(version)
-    if version >= '1.12.4'
+    if version >= '3.0.0'
+      %w{pusher.js pusher.min.js json2.js json2.min.js sockjs.js sockjs.min.js}
+    elsif version >= '1.12.4'
       %w{pusher.js pusher.min.js flashfallback.js flashfallback.min.js json2.js
          json2.min.js sockjs.js sockjs.min.js WebSocketMain.swf}
     elsif version >= '1.6.2'
@@ -145,6 +148,14 @@ helpers do
       %w{pusher.js pusher.min.js WebSocketMain.swf}
     else
       %w{pusher.js}
+    end
+  end
+  
+  def supported_transports(version)
+    if version >= '3.0.0'
+      %w{ws xhr_streaming xdr_streaming xhr_polling xdr_polling sockjs}
+    else
+      %w{ws flash xhr_streaming xdr_streaming xhr_polling xdr_polling sockjs}
     end
   end
 

--- a/views/public.erb
+++ b/views/public.erb
@@ -49,7 +49,7 @@
     <% if @version >= '2.0.0' %>
       <h4>Select transports</h4>
       <ul id="transports">
-        <% ["ws", "flash", "xhr_streaming", "xdr_streaming", "xhr_polling", "xdr_polling", "sockjs"].each do |transport| %>
+        <% supported_transports(@version).each do |transport| %>
           <li>
             <input type="checkbox" id="transport_<%= transport %>">
             <%= transport %>
@@ -101,7 +101,7 @@ $(document).ready(function() {
   Pusher.sockjs_https_port = <%= @env[:sockjs_https_port] %>;
 
   <% if @version >= "2.0.0" %>
-    bindTransportCheckboxes(<%= @ssl %>, <%= JSON.generate(@transports) %>);
+    bindTransportCheckboxes(<%= @ssl %>, <%= JSON.generate(@selected_transports) %>);
   <% end %>
 
   bindLogCheckboxes(logger.types);


### PR DESCRIPTION
Since pusher-js 3.0 doesn't support flash a few additional filters had to be added in order to remove it from being a transport option and so that the flash-related files weren't listed.

cc: @zimbatm 